### PR TITLE
add events for customizing controls on simple item types

### DIFF
--- a/includes/page-builder/includes/item-types/simple/static/js/scripts.js
+++ b/includes/page-builder/includes/item-types/simple/static/js/scripts.js
@@ -138,16 +138,16 @@
 				 *   }
 				 * );
 				 *
-                 * You can make changes to controls to a single shortcode by
-                 * checking the value of data.model.get('shortcode').
-                 *
+				 * You can make changes to controls to a single shortcode by
+				 * checking the value of data.model.get('shortcode').
+				 *
 				 * fwEvents.on(
 				 *   'fw:page-builder:shortcode:item-simple:controls',
 				 *   function (data) {
-                 *     if (data.model.get('shortcode') !== 'my_desired_shortcode') {
-                 *       return;
-                 *     }
-                 *
+				 *     if (data.model.get('shortcode') !== 'my_desired_shortcode') {
+				 *       return;
+				 *     }
+				 *
 				 *     // Change controls
 				 *   }
 				 * );

--- a/includes/page-builder/includes/item-types/simple/static/js/scripts.js
+++ b/includes/page-builder/includes/item-types/simple/static/js/scripts.js
@@ -126,21 +126,6 @@
 				});
 
 				/**
-				 * Trigger events on a more general-purpose fwEvents.
-				 * Not everyone has access to this.model right away.
-				 */
-				var singleShortcodeEvent =
-					'fw:page-builder:shortcode:item-simple:' +
-					this.model.get('shortcode') +
-					':controls';
-
-				fwEvents.trigger(singleShortcodeEvent, {
-					$controls: this.$('.controls:first'),
-					model: this.model,
-					builder: builder
-				});
-
-				/**
 				 * You can handle all shortcodes that are of type simple
 				 * at once * with * this event.
 				 *
@@ -152,7 +137,20 @@
 				 *     console.log(data.model.get('shortcode'));
 				 *   }
 				 * );
-				 * 
+				 *
+                 * You can make changes to controls to a single shortcode by
+                 * checking the value of data.model.get('shortcode').
+                 *
+				 * fwEvents.on(
+				 *   'fw:page-builder:shortcode:item-simple:controls',
+				 *   function (data) {
+                 *     if (data.model.get('shortcode') !== 'my_desired_shortcode') {
+                 *       return;
+                 *     }
+                 *
+				 *     // Change controls
+				 *   }
+				 * );
 				 */
 				fwEvents.trigger('fw:page-builder:shortcode:item-simple:controls', {
 					$controls: this.$('.controls:first'),

--- a/includes/page-builder/includes/item-types/simple/static/js/scripts.js
+++ b/includes/page-builder/includes/item-types/simple/static/js/scripts.js
@@ -124,6 +124,41 @@
 				triggerEvent(this.model, 'controls', {
 					$controls: this.$('.controls:first')
 				});
+
+				/**
+				 * Trigger events on a more general-purpose fwEvents.
+				 * Not everyone has access to this.model right away.
+				 */
+				var singleShortcodeEvent =
+					'fw:page-builder:shortcode:item-simple:' +
+					this.model.get('shortcode') +
+					':controls';
+
+				fwEvents.trigger(singleShortcodeEvent, {
+					$controls: this.$('.controls:first'),
+					model: this.model,
+					builder: builder
+				});
+
+				/**
+				 * You can handle all shortcodes that are of type simple
+				 * at once * with * this event.
+				 *
+				 * Getting the shortcode name is as simple as:
+				 *
+				 * fwEvents.on(
+				 *   'fw:page-builder:shortcode:item-simple:controls',
+				 *   function (data) {
+				 *     console.log(data.model.get('shortcode'));
+				 *   }
+				 * );
+				 * 
+				 */
+				fwEvents.trigger('fw:page-builder:shortcode:item-simple:controls', {
+					$controls: this.$('.controls:first'),
+					model: this.model,
+					builder: builder
+				});
 			},
 			events: {
 				'click': 'editOptions',
@@ -206,3 +241,4 @@
 		builder.registerItemClass(PageBuilderSimpleItem);
 	});
 })(fwEvents, _, page_builder_item_type_simple_data);
+


### PR DESCRIPTION
Adding those events is a good idea because of three reasons:

1. We want to be consistent with the way [section](https://github.com/ThemeFuse/Unyson-Shortcodes-Extension/blob/2319d1f750abf0ac6a9e08cdf434cfb6accee559/shortcodes/section/includes/page-builder-section-item/static/js/scripts.js#L145) and [column](https://github.com/ThemeFuse/Unyson-Shortcodes-Extension/blob/2319d1f750abf0ac6a9e08cdf434cfb6accee559/shortcodes/column/includes/page-builder-column-item/static/js/scripts.js#L129) works.
2. We want a general purpose event like `fw:page-builder:shortcode:item-simple:controls` to handle all shortcodes. Probably is a good idea to rename it to `fw:page-builder:shortcode:controls` and trigger it for _section_ and _column_ also. What do you think?

3. Not everyone have the [model](https://github.com/andreiglingeanu/Unyson-PageBuilder-Extension/blob/master/includes/page-builder/includes/item-types/simple/static/js/scripts.js#L124) accessible in order to listen to this event.