### PR TITLE
Fix get_post_content_shortcodes tenfolding the number of queries

### DIFF
--- a/class-fw-extension-page-builder.php
+++ b/class-fw-extension-page-builder.php
@@ -303,7 +303,7 @@ class FW_Extension_Page_Builder extends FW_Extension {
 		if (
 			post_type_supports(
 				get_post_type(
-					($post_revision_id = wp_is_post_revision($post)) ? $post_revision_id : $post->ID
+					($post_revision_id = wp_is_post_revision($post)) ? $post_revision_id : $post
 				),
 				$this->supports_feature_name
 			)


### PR DESCRIPTION
This little typo causes the number of queries to rise through the roof as `get_post_type` does an additional query if supplied with an ID instead of a post.