### PR TITLE
Shortcodes Eye: Hide elements from Page-Builder.

### DIFF
--- a/includes/page-builder/class-fw-option-type-page-builder.php
+++ b/includes/page-builder/class-fw-option-type-page-builder.php
@@ -4,6 +4,8 @@ class FW_Option_Type_Page_Builder extends FW_Option_Type_Builder
 {
 	private $editor_integration_enabled = false;
 
+	private $shortcode_visibility_property = 'fw-visibility';
+
 	public function get_type()
 	{
 		return 'page-builder';
@@ -65,6 +67,25 @@ class FW_Option_Type_Page_Builder extends FW_Option_Type_Builder
 				array('jquery', 'fw-events'),
 				$version,
 				true
+			);
+
+			wp_enqueue_script(
+				'fw-option-type-' . $this->get_type() . '-shortcode-eye',
+				$static_uri . '/js/shortcodes-eye.js',
+				array('jquery', 'fw-events'),
+				$version,
+				true
+			);
+
+			wp_localize_script(
+				'fw-option-type-' . $this->get_type() . '-shortcode-eye',
+				'_fw_option_type_page_builder_shortcodes_eye',
+				array(
+					'l10n' => array(
+						'tooltip' => __('Hide / Show', 'fw'),
+					),
+					'key' => $this->shortcode_visibility_property,
+				)
 			);
 
 			{
@@ -268,6 +289,30 @@ class FW_Option_Type_Page_Builder extends FW_Option_Type_Builder
 		}
 
 		return $mceInit;
+	}
+
+	protected function storage_load_recursive(array $items, array $params) {
+		$item_types = $this->get_item_types();
+
+		foreach ($items as &$atts) {
+			if( ! fw_akg( $this->shortcode_visibility_property, $atts, true ) && ! is_admin() ) {
+				// Hide shortcode JSON only in front-end.
+				$atts = array();
+				continue;
+			}
+
+			if (!isset($atts['type']) || !isset($item_types[ $atts['type'] ])) {
+				continue; // invalid item
+			}
+
+			$atts = $item_types[ $atts['type'] ]->storage_load($atts, $params);
+
+			if (isset($atts['_items'])) {
+				$atts['_items'] = $this->storage_load_recursive($atts['_items'], $params);
+			}
+		}
+
+		return $items;
 	}
 }
 

--- a/includes/page-builder/class-fw-option-type-page-builder.php
+++ b/includes/page-builder/class-fw-option-type-page-builder.php
@@ -291,6 +291,9 @@ class FW_Option_Type_Page_Builder extends FW_Option_Type_Builder
 		return $mceInit;
 	}
 
+	/**
+	 * https://github.com/ThemeFuse/Unyson-Builder-Extension/blob/v1.2.3/includes/option-types/builder/extends/class-fw-option-type-builder.php#L597
+	 */
 	protected function storage_load_recursive(array $items, array $params) {
 		$item_types = $this->get_item_types();
 

--- a/includes/page-builder/static/css/styles.css
+++ b/includes/page-builder/static/css/styles.css
@@ -46,3 +46,7 @@
 .fw-option-type-page-builder .builder-item-type:hover p span {
 	color: #484848;
 }
+
+.fw-option-type-page-builder .fw-visibility-off {
+    opacity: 0.6;
+}

--- a/includes/page-builder/static/js/shortcodes-eye.js
+++ b/includes/page-builder/static/js/shortcodes-eye.js
@@ -1,0 +1,82 @@
+(function( $, itemData ) {
+    
+    var visibleIcon = 'dashicons-visibility',
+	hiddenIcon = 'dashicons-hidden';
+    
+    /**
+     * Change model visibility attribute and shortcode class.
+     * @param {Object} model
+     */
+    function visibilitySettings( model ) {
+	var visibility = model.get( itemData.key );
+	var element = $(model.view.el);
+
+	if( visibility || 'undefined' === typeof( visibility ) ) {
+	    element.addClass('fw-visibility-off');
+	    model.set( itemData.key, false );
+	} else {
+	    element.removeClass( 'fw-visibility-off' );
+	    model.set( itemData.key, true );
+	}
+    }
+    
+    /**
+     * Change dashicons and shortcode visibility class.
+     * @param {Object} model
+     */
+    function displayIcon( model ) {
+	var visibility = model.get( itemData.key );
+	var element = $(model.view.el);
+	var icon = element.find('.fw-shortcode-visibility:first');
+	
+	if( visibility || 'undefined' === typeof( visibility ) ) {
+	    element.removeClass('fw-visibility-off');
+	    icon.removeClass( hiddenIcon );
+	    icon.addClass( visibleIcon );
+	} else {
+	    element.addClass('fw-visibility-off');
+	    icon.removeClass( visibleIcon );
+	    icon.addClass( hiddenIcon );
+	}
+    }
+    
+    /**
+     * Add eye icon to elements.
+     * @param {Object} data
+     */
+    function addIcon( data ) {
+	data.$controls.prepend(
+	    $('<i class="fw-shortcode-visibility dashicons dashicons-visibility"></i>')
+	    .attr('data-hover-tip', itemData.l10n.tooltip)
+	    .on('click', function(e) {
+		e.stopPropagation();
+		e.preventDefault();
+		
+		visibilitySettings( data.model );
+	    })
+	);
+
+	displayIcon( data.model )
+    }
+    
+    // Add controls for simple shortcodes.
+    fwEvents.on('fw:page-builder:shortcode:item-simple:controls', function( data ) {
+	addIcon( data );
+    });
+    
+    // Add controls for sections.
+    fwEvents.on('fw:page-builder:shortcode:section:controls', function(data) {
+	addIcon( data );
+    });
+
+    // Add controls for columns.
+    fwEvents.on('fw:page-builder:shortcode:column:controls', function(data) {
+	addIcon( data );
+    });
+    
+    // Add controls for contact form.
+    fwEvents.on('fw:page-builder:shortcode:contact-form:controls', function(data) {
+	addIcon( data );
+    });
+    
+})( jQuery, _fw_option_type_page_builder_shortcodes_eye );


### PR DESCRIPTION
Done!
https://github.com/ThemeFuse/Unyson/issues/662

Hide shortcodes, sections and columns in front-end.

Backend:
![Backend](https://i.gyazo.com/54ccda08205c40ed93527a99883dd316.gif)

Frontend:
![Frontend](https://i.gyazo.com/8e8ba6db6c131930841da12e05c3450e.gif)