### PR TITLE
Filter for REST API Single Page Request

### DIFF
--- a/class-fw-extension-page-builder.php
+++ b/class-fw-extension-page-builder.php
@@ -80,7 +80,7 @@ class FW_Extension_Page_Builder extends FW_Extension {
 		/** @since 1.6.15 */
 		add_action( 'rest_api_init', array( $this, '_rest_api_init' ) );
 	}
-	
+
 	/**
 	 * Sets up filters when being called from WordPress REST API
 	 *
@@ -95,7 +95,7 @@ class FW_Extension_Page_Builder extends FW_Extension {
 		// Fixes: https://github.com/ThemeFuse/Unyson/issues/2754
 		add_filter( 'the_content', array( $this, '_rest_api_the_content_filter_the_posts' ), 2 );
 	}
-	
+
 	/**
 	 * Processes the page builder shortcodes when called from the REST API
 	 *
@@ -110,18 +110,7 @@ class FW_Extension_Page_Builder extends FW_Extension {
 	 * @return string The post content after any page builder shortcodes are processed
 	 */
 	public function _rest_api_the_content_filter_the_posts() {
-		// '_filter_the_posts' expects $posts to be an array, not just a WP_Post object
-		$posts[] = get_post();
-		
-		// The second parameter to '_filter_the_posts' is only needed as wp-includes/class-wp-query.php
-		// calls `$this->posts = apply_filters_ref_array( 'the_posts', array( $this->posts, &$this ) );`
-		// As '_filter_the_posts' doesn't use the second parameter, an null value can
-		// be passed (as opposed to setting a default value for the function parameter)
-		$content = $this->_filter_the_posts( $posts, null );
-		
-		// A multidimensional array is returned by '_filter_the_posts', so get
-		// the post content from the first array item only
-		return $content[0]->post_content;
+		return fw_ext_page_builder_get_post_content(get_post());
 	}
 
 	/*

--- a/class-fw-extension-page-builder.php
+++ b/class-fw-extension-page-builder.php
@@ -112,8 +112,13 @@ class FW_Extension_Page_Builder extends FW_Extension {
 	public function _rest_api_the_content_filter_the_posts() {
 		// '_filter_the_posts' expects $posts to be an array, not just a WP_Post object
 		$posts[] = get_post();
-		$query = new WP_Query();
-		$content = $this->_filter_the_posts( $posts, $query );
+		
+		// The second parameter to '_filter_the_posts' is only needed as wp-includes/class-wp-query.php
+		// calls `$this->posts = apply_filters_ref_array( 'the_posts', array( $this->posts, &$this ) );`
+		// As '_filter_the_posts' doesn't use the second parameter, an null value can
+		// be passed (as opposed to setting a default value for the function parameter)
+		$content = $this->_filter_the_posts( $posts, null );
+		
 		// A multidimensional array is returned by '_filter_the_posts', so get
 		// the post content from the first array item only
 		return $content[0]->post_content;


### PR DESCRIPTION
When a single page is requested via the WordPress REST API (`<server>/wp-json/wp/v2/pages/<page_id>`) no page builder shortcodes are processed for the 'rendered' content returned in the JSON response. This is due to neither 'the_posts' nor 'get_pages' filter hooks being called when a single page is requested from the REST API, only 'the_content'.

This pull request corrects this issue by:
* Only performing processing if the request is from the REST API (to prevent making any unwanted changes to 'the_content')
* Making sure that the page content passes through the page builder shortcode generation functions to generate the HTML markup before being shown in the JSON response

See: https://github.com/ThemeFuse/Unyson/issues/2754