### PR TITLE
added pregreplace to strip contents of <script> tags in content

### DIFF
--- a/class-fw-extension-page-builder.php
+++ b/class-fw-extension-page-builder.php
@@ -210,6 +210,7 @@ class FW_Extension_Page_Builder extends FW_Extension {
 			$post_content = $option_type->json_to_shortcodes( $builder_data['json'] );
 			$post_content = str_replace('\\', '\\\\', $post_content); // WordPress "fixes" the slashes
 			$post_content = do_shortcode($post_content);
+			$post_content = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $post_content);
 			$post_content = strip_tags($post_content, '<a><p><h1><h2><h3><h4><h5><h6><img>');
 			$post_content = trim($post_content);
 			$post_content = implode("\n", array_filter(explode("\n", $post_content), 'trim')); // remove extra \n

--- a/class-fw-extension-page-builder.php
+++ b/class-fw-extension-page-builder.php
@@ -211,10 +211,7 @@ class FW_Extension_Page_Builder extends FW_Extension {
 			$post_content = str_replace('\\', '\\\\', $post_content); // WordPress "fixes" the slashes
 			$post_content = do_shortcode($post_content);
 			$post_content = preg_replace('#<script(.*?)>(.*?)</script>#is', '', $post_content);
-			$post_content = strip_tags($post_content, '<a><p><h1><h2><h3><h4><h5><h6><img>');
-			$post_content = trim($post_content);
-			$post_content = implode("\n", array_filter(explode("\n", $post_content), 'trim')); // remove extra \n
-			$post_content = normalize_whitespace($post_content);
+			$post_content = wp_kses_post( $post_content );
 
 			// In case some shortcode option has been changed but it doesn't have impact on html
 			$post_content .= "\n\n". '<!-- '. md5($builder_data['json']) .' -->';


### PR DESCRIPTION
I've encountered an issue in which a third-party theme provides a shortcode that includes inline js in its view template. When the post is saved strip_tags() is called on the content which strips the enclosing <script> tags but leaves the inner content. This change removes the tag and its content. This allows functions such as the_excerpt() to behave as expected.